### PR TITLE
use only first namespace when matching

### DIFF
--- a/src/mutils/namespace.py
+++ b/src/mutils/namespace.py
@@ -51,7 +51,7 @@ def getFromDagPath(dagPath):
     :rtype: str
     """
     shortName = dagPath.split("|")[-1]
-    namespace = ":".join(shortName.split(":")[:-1])
+    namespace = shortName.split(":")[0]
     return namespace
 
 

--- a/src/mutils/node.py
+++ b/src/mutils/node.py
@@ -97,7 +97,7 @@ class Node(object):
         :rtype: str
         """
         if self._namespace is None:
-            self._namespace = ":".join(self.shortname().split(":")[:-1])
+            self._namespace = self.shortname().split(":")[0]
         return self._namespace
 
     def stripFirstPipe(self):


### PR DESCRIPTION
Fixes applying of poses, anims, and selection sets with nested namespaces - which we use to organize rig components within ZAM's rigging pipeline